### PR TITLE
Allowed access to pubternals when declared as basetype

### DIFF
--- a/source/gfoidl.Analyzers/PubternalityAnalyzer.cs
+++ b/source/gfoidl.Analyzers/PubternalityAnalyzer.cs
@@ -36,17 +36,20 @@ namespace gfoidl.Analyzers
             IdentifierNameSyntax identifier = syntaxContext.Node as IdentifierNameSyntax;
 
             TypeInfo symbolInfo = ModelExtensions.GetTypeInfo(syntaxContext.SemanticModel, identifier, syntaxContext.CancellationToken);
+            ITypeSymbol type    = symbolInfo.Type;
 
-            if (symbolInfo.Type == null)
+            if (type == null)
                 return;
-
-            ITypeSymbol type = symbolInfo.Type;
 
             if (!IsInternal(type.ContainingNamespace))
             {
                 // don't care about non-pubternal type references
                 return;
             }
+
+            SyntaxNode parent = identifier.Parent;
+            if (parent.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+                return;
 
             if (!syntaxContext.ContainingSymbol.ContainingAssembly.Equals(type.ContainingAssembly))
                 syntaxContext.ReportDiagnostic(Diagnostic.Create(

--- a/tests/gfoidl.Analyzers.Tests/DiagnosticVerifier.cs
+++ b/tests/gfoidl.Analyzers.Tests/DiagnosticVerifier.cs
@@ -36,7 +36,7 @@ namespace gfoidl.Analyzers.Tests
                 Compilation compilation = await project.GetCompilationAsync();
 
                 // Enable any additional diagnostics
-                Microsoft.CodeAnalysis.CompilationOptions options = compilation.Options;
+                CompilationOptions options = compilation.Options;
 
                 if (additionalEnabledDiagnostics?.Length > 0)
                 {

--- a/tests/gfoidl.Analyzers.Tests/Tests/PubternalityAnalyzerTests.cs
+++ b/tests/gfoidl.Analyzers.Tests/Tests/PubternalityAnalyzerTests.cs
@@ -27,7 +27,7 @@ namespace MyProgram
 {
     internal class Worker
     {
-        private /*MM*/Bar _bar = new Bar();
+        private Bar _bar = new Bar();
     }
 }");
             Diagnostic[] diagnostics = await this.GetDiagnosticsWithProjectReference(code.Source, library);
@@ -48,6 +48,50 @@ namespace MyLib
         private static readonly Bar s_bar = new Bar();
 
         public static Bar Default => s_bar;
+
+        public abstract void Do();
+    }
+}
+
+namespace MyLib.Internal
+{
+    public sealed class Bar : Base
+    {
+        public override void Do() { }
+    }
+}";
+
+            TestSource code = TestSource.Read(@"
+using MyLib;
+
+namespace MyProgram
+{
+    internal class Worker
+    {
+        public void Work()
+        {
+            Base.Default.Do();
+        }
+    }
+}");
+            Diagnostic[] diagnostics = await this.GetDiagnosticsWithProjectReference(code.Source, library);
+
+            Assert.AreEqual(0, diagnostics.Length);
+        }
+        //---------------------------------------------------------------------
+        [Test]
+        public async Task Issue_1_public_type_declared_and_used___no_warning_or_error()
+        {
+            string library = @"
+namespace MyLib
+{
+    using MyLib.Internal;
+
+    public abstract class Base
+    {
+        private static readonly Bar s_bar = new Bar();
+
+        public static Base Default => s_bar;
 
         public abstract void Do();
     }


### PR DESCRIPTION
So patterns like

```c#
namespace MyLib
{
    using MyLib.Internal;

    public abstract class Base
    {
        private static readonly Bar s_bar = new Bar();

        public static Bar Default => s_bar;

        public abstract void Do();
    }
}

namespace MyLib.Internal
{
    public sealed class Bar : Base
    {
        public override void Do() { }
    }
}
```

```c#
using MyLib;

namespace MyProgram
{
    internal class Worker
    {
        public void Work()
        {
            Base.Default.Do();
        }
    }
}
```
are permitted.

Fixes #1